### PR TITLE
Limit number of results to 10

### DIFF
--- a/server_modules/mongoose.js
+++ b/server_modules/mongoose.js
@@ -290,7 +290,7 @@ let beaches = {
         return await beachModel.find({}, "n lat lon").exec();
     },
     queryBeachNames: async function(query) {
-        return await beachModel.find({ n: { $regex: `${query}`, $options: "i" } }).select("n").exec();
+        return await beachModel.find({ n: { $regex: `${query}`, $options: "i" } }).select("n").limit(10).exec();
     },
     getOneLonLat: async function(beachID) {
         let projection = `lat lon`


### PR DESCRIPTION
Hard coded result limit to 10. Not a permanent solution but enough to stop it from fetching too much data.